### PR TITLE
Vector2 float32 operator fixes and TestApp project link improvement

### DIFF
--- a/Libs/ecm/math/vector2.inl
+++ b/Libs/ecm/math/vector2.inl
@@ -93,7 +93,7 @@ namespace ecm::math
 	{
 		Vector2 vec{};
 		vec.x = left.x + right;
-		vec.x = left.y + right;
+		vec.y = left.y + right;
 		return vec;
 	}
 
@@ -101,7 +101,7 @@ namespace ecm::math
 	{
 		Vector2 vec{};
 		vec.x = left.x - right;
-		vec.x = left.y - right;
+		vec.y = left.y - right;
 		return vec;
 	}
 
@@ -109,7 +109,7 @@ namespace ecm::math
 	{
 		Vector2 vec{};
 		vec.x = left.x * right;
-		vec.x = left.y * right;
+		vec.y = left.y * right;
 		return vec;
 	}
 
@@ -117,7 +117,7 @@ namespace ecm::math
 	{
 		Vector2 vec{};
 		vec.x = left.x / right;
-		vec.x = left.y / right;
+		vec.y = left.y / right;
 		return vec;
 	}
 

--- a/TestApps/TestApp/TestApp.vcxproj
+++ b/TestApps/TestApp/TestApp.vcxproj
@@ -167,20 +167,11 @@
     <ProjectReference Include="..\..\Libs\ecm.algorithm.vcxproj">
       <Project>{94053112-848b-47e9-86e1-2b67e9452863}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\Libs\ecm.algorithm\ecm.algorithm.vcxproj">
-      <Project>{94053112-848b-47e9-86e1-2b67e9452863}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\..\Libs\ecm.vcxproj">
       <Project>{b2ee1486-2dd9-441c-8c02-a27280a38b13}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\Libs\ecm.window.vcxproj">
       <Project>{49a18b56-b187-4f1e-ae63-c2d2a9a51bba}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Libs\ecm.window\ecm.window.vcxproj">
-      <Project>{49a18b56-b187-4f1e-ae63-c2d2a9a51bba}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Libs\ecm\ecm.vcxproj">
-      <Project>{b2ee1486-2dd9-441c-8c02-a27280a38b13}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Vector2 float32 operators used x instead y for second coordinate.
Old project links in TestApp removed.